### PR TITLE
Fix order of tables creation

### DIFF
--- a/tables.sql
+++ b/tables.sql
@@ -1,3 +1,13 @@
+-- Create syntax for TABLE 'group'
+CREATE TABLE `group` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) NOT NULL,
+  `variables` longtext,
+  `enabled` tinyint(1) NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `group_name` (`name`)
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
+
 -- Create syntax for TABLE 'childgroups'
 CREATE TABLE `childgroups` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -9,23 +19,6 @@ CREATE TABLE `childgroups` (
   KEY `childgroups_parent_id` (`parent_id`),
   CONSTRAINT `childgroups_ibfk_1` FOREIGN KEY (`child_id`) REFERENCES `group` (`id`),
   CONSTRAINT `childgroups_ibfk_2` FOREIGN KEY (`parent_id`) REFERENCES `group` (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
-
--- Create syntax for VIEW 'children'
-CREATE VIEW `children`
-AS SELECT
-   `gparent`.`name` AS `parent`,
-   `gchild`.`name` AS `child`
-FROM ((`childgroups` left join `group` `gparent` on((`childgroups`.`parent_id` = `gparent`.`id`))) left join `group` `gchild` on((`childgroups`.`child_id` = `gchild`.`id`))) order by `gparent`.`name`;
-
--- Create syntax for TABLE 'group'
-CREATE TABLE `group` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `name` varchar(255) NOT NULL,
-  `variables` longtext,
-  `enabled` tinyint(1) NOT NULL,
-  PRIMARY KEY (`id`),
-  UNIQUE KEY `group_name` (`name`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
 
 -- Create syntax for TABLE 'host'
@@ -61,3 +54,10 @@ AS SELECT
    `host`.`hostname` AS `hostname`,
    `host`.`variables` AS `host_vars`
 FROM (`group` left join (`host` left join `hostgroups` on((`host`.`id` = `hostgroups`.`host_id`))) on((`hostgroups`.`group_id` = `group`.`id`))) where ((`host`.`enabled` = 1) and (`group`.`enabled` = 1)) order by `host`.`hostname`;
+
+-- Create syntax for VIEW 'children'
+CREATE VIEW `children`
+AS SELECT
+   `gparent`.`name` AS `parent`,
+   `gchild`.`name` AS `child`
+FROM ((`childgroups` left join `group` `gparent` on((`childgroups`.`parent_id` = `gparent`.`id`))) left join `group` `gchild` on((`childgroups`.`child_id` = `gchild`.`id`))) order by `gparent`.`name`;


### PR DESCRIPTION
The order of tables creation results in initial foreign key addition to fail, and thus the whole batch fails with error. This change is to fix it so the schema can be imported successfully in single run.