### PR TITLE
Configurable host key and set of inventory groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,17 +30,24 @@ Once setup rename `mysql.ini.dist` to `mysql.ini` to suit your needs, if you don
 In the table `group` you create the groups you need and their variables,
 
 ### Hosts
-In the table `host` under `host` you place the IP/DNS for the system.
+In the table `host` under `host` you place the IP/DNS for the system. This will be used as ansible_host fact.
 
-#### Facts
-Under `hostname` you can fill in a value, this will be presented as a variable `inventory_hostname` during the play.
-You can modify the name of this Fact variable by changing the `facts_hostname_var` variable in my `mysql.ini`.
+#### Inventory_hostname
+Under `hostname` you can fill in a unique hostname, this will typically be used as the host's primary key (==`inventory_hostname`).
+You can modify the field to be used as `inventory_hostname` by changing the `inventory_hostname` variable in `mysql.ini`.
+Make sure this is a unique key field (e.g. `host` or `hostname`), the default for `inventory_hostname` is `host` (backward compatible).
 
 ### Relation between Hosts and Groups
 The table `hostgroups` maps the relation between `host` and `group` using two `FOREIGN KEYS`.
 
 #### Children
 Groups can have other groups as children, use the table `childgroups`.
+
+
+#### Inventory_groups
+By default only groups from `hostgroups` and groups from `childgroups` having a child group from `hostgroups` will be included into the inventory (i.e. max. two group levels).
+You can include all groups from `hostgroups`and `childgroups` by changing the `inventory_groups` variable in `mysql.ini` to `all`.
+This allows you to define group hierarchies of any depth and complexity.
 
 ### Note on Variables
 This applies to `host` and `group` respectively.

--- a/mysql.ini.dist
+++ b/mysql.ini.dist
@@ -22,5 +22,14 @@ cache_path = /tmp
 # seconds, a new API call will be made, and the cache file will be updated.
 cache_max_age = 0
 
-# Facts variable for the hostname
-facts_hostname_var = inventory_hostname
+# Define which unique key should be used as inventory_hostname:
+#    host (default)
+#    hostname
+inventory_hostname = hostname
+
+# Define the set of `children` to include in inventory:
+#	immediate: (default) 
+#               groups from `hostgroups` (i.e.: groups containing hosts from `host`) plus
+#               groups from `childgroup` having childs from `hostgroups`
+#	all:        any group mentioned in `group` or childgroup`
+inventory_groups = all

--- a/mysql.ini.dist
+++ b/mysql.ini.dist
@@ -5,7 +5,7 @@
 
 host = YOURHOST
 user = YOURUSER
-passwd = YOURPASSWORD
+passwd = 
 db = YOURDB
 port = 3306
 

--- a/mysql.py
+++ b/mysql.py
@@ -106,11 +106,11 @@ class MySQLInventory(object):
 
         # Other config
         try:
-		    self.inventory_hostname = config.get('config', 'inventory_hostname') 
+            self.inventory_hostname = config.get('config', 'inventory_hostname') 
         except:
             self.inventory_hostname = 'host'
         try:
-		    self.inventory_groups = config.get('config', 'inventory_groups') 
+            self.inventory_groups = config.get('config', 'inventory_groups') 
         except:
             self.inventory_groups = 'immediate'
 

--- a/tables.sql
+++ b/tables.sql
@@ -61,3 +61,10 @@ AS SELECT
    `gparent`.`name` AS `parent`,
    `gchild`.`name` AS `child`
 FROM (((`childgroups` left join `group` `gparent` on((`childgroups`.`parent_id` = `gparent`.`id`))) left join `group` `gchild` on((`childgroups`.`child_id` = `gchild`.`id`))) left join `inventory` on((`gchild`.`name` = `inventory`.`group`))) where ((`gparent`.`enabled` = 1) and (`gchild`.`enabled` = 1) and (`inventory`.`hostname` is not null)) group by `gparent`.`name`,`gchild`.`name` order by `gparent`.`name`;
+
+-- Create syntax for VIEW 'children_all'
+CREATE VIEW `children_all`
+AS select 
+    `gparent`.`name` AS `parent`,
+    `gchild`.`name` AS `child` 
+FROM ((`childgroups` left join `group` `gparent` on((`childgroups`.`parent_id` = `gparent`.`id`))) left join `group` `gchild` on((`childgroups`.`child_id` = `gchild`.`id`))) where ((`gparent`.`enabled` = 1) and (`gchild`.`enabled` = 1)) group by `gparent`.`name`,`gchild`.`name` order by `gparent`.`name`;


### PR DESCRIPTION
Bugfixes:
---------
- Fixed an exception in line 189 (cleanup output)

Modifications:
--------------
- Configurable host key / inventory_hostname:
  Ansible (at least v2.9) uses the host key from the inventory plugin
  as inventory_hostname, not the host fact inventory_hostname.
  - dropped support for setting 'facts_hostname_var'
  - added setting 'inventory_hostname'
  - use the field defined in 'inventory_hostname' as host key
  - add fact host['ansible_host']= host

Enhancements:
-------------
- Configurable set of inventory groups:
  By default only groups from `hostgroups` and groups from `childgroups`
  having a child group from `hostgroups` will be included into the inventory
  (i.e. max. two group levels).
  You can include all groups from `hostgroups`and `childgroups` by changing
  the `inventory_groups` variable in `mysql.ini` to `all`.
  This allows you to define group hierarchies of any depth and complexity.
  - added new db table view 'children_all'
  - added new variable 'inventory_groups' to mysql.ini
  - use db table view 'children_all' if 'inventory_groups' is set to 'all'